### PR TITLE
Issue #3 - Add GPS time display to clock component

### DIFF
--- a/bliss/gui/__init__.py
+++ b/bliss/gui/__init__.py
@@ -62,7 +62,7 @@ import requests
 
 import bliss.core
 
-from bliss.core import api, ccsds, cfg, cmd, evr, gds, limits, log, pcap, tlm
+from bliss.core import api, ccsds, cfg, cmd, dmc, evr, gds, limits, log, pcap, tlm
 from bliss.core import util
 
 
@@ -728,6 +728,23 @@ def handle():
 def handle():
     """Expose bliss.config.data info to the frontend"""
     return json.dumps(bliss.config._datapaths)
+
+
+@App.route('/leapseconds', method='GET')
+def handle():
+    """Return UTC-GPS Leapsecond data
+
+    **Example Response**:
+
+    .. sourcecode: json
+
+       [
+           ["1981-07-01 00:00:00", 1],
+           ["1982-07-01 00:00:00", 2],
+           ["1983-07-01 00:00:00", 3]
+       ]
+    """
+    return json.dumps(dmc.LeapSeconds.leapseconds, default=str)
 
 
 @App.route('/seq', method='GET')

--- a/bliss/gui/static/js/bliss/format.js
+++ b/bliss/gui/static/js/bliss/format.js
@@ -17,17 +17,23 @@
 import { DOY, timezone } from './time'
 
 
-function date (obj, { doy = false, utc = true } = {}) {
-    let   yyyy, mm, dd, formatted
-    const date = normalize(obj)
+function adjustUTCtoGPS(obj, {gps = true, utc_gps_offset = 0}) {
+    if (gps) {
+        let datetime = normalize(obj)
+        datetime.setSeconds(datetime.getSeconds() + utc_gps_offset)
+    }
+}
 
 
-    if (utc) {
+function date (obj, { doy = false, gps = true } = {}) {
+    let yyyy, mm, dd, formatted
+    let date = normalize(obj)
+
+    if (gps || utc) {
         yyyy = date.getUTCFullYear()
         mm   = date.getUTCMonth()
         dd   = date.getUTCDate()
-    }
-    else {
+    } else {
         yyyy = date.getFullYear()
         mm   = date.getMonth()
         dd   = date.getDate()
@@ -87,18 +93,16 @@ function pad3 (n) {
 }
 
 
-function time (obj, { h24 = true, utc = true } = {}) {
-    let   hh, mm, ss, formatted
-    let   suffix = ' AM'
-    const time   = normalize(obj)
+function time (obj, { h24 = true, gps = true } = {}) {
+    let hh, mm, ss, formatted
+    let suffix = ' AM'
+    let time = normalize(obj)
 
-
-    if (utc) {
+    if (gps || utc) {
         hh = time.getUTCHours()
         mm = time.getUTCMinutes()
         ss = time.getUTCSeconds()
-    }
-    else {
+    } else {
         hh = time.getHours()
         mm = time.getMinutes()
         ss = time.getSeconds()            
@@ -119,9 +123,15 @@ function time (obj, { h24 = true, utc = true } = {}) {
 }
 
 
-function tz (obj, { utc = true } = {}) {
-    return utc ? 'UTC' : timezone(obj)
+function tz (obj, { utc = false, gps = true } = {}) {
+    if (gps) {
+        return 'GPS'
+    } else if (utc) {
+        return 'UTC'
+    } else {
+        return timezone(obj)
+    }
 }
 
 
-export { date, datetime, time, tz }
+export { date, datetime, time, tz, adjustUTCtoGPS }

--- a/bliss/gui/static/test/test_clock.js
+++ b/bliss/gui/static/test/test_clock.js
@@ -33,11 +33,16 @@ describe('Clock object', function () {
         clock._h24.should.equal(false)
     })
 
-    it('should allow for toggling to/from UTC time', function() {
+    it('should allow for toggling to/from GPS/UTC/Local time', function() {
         var clock = bliss.gui.Clock
-        clock._utc.should.equal(true)
-        clock.toggleUTC()
         clock._utc.should.equal(false)
+        clock._gps.should.equal(true)
+        clock.toggleTimeFormat()
+        clock._utc.should.equal(true)
+        clock._gps.should.equal(false)
+        clock.toggleTimeFormat()
+        clock._utc.should.equal(false)
+        clock._gps.should.equal(false)
     })
 
     it('should allow for toggling Julian date to/from DOY', function() {


### PR DESCRIPTION
The clock component now displays GPS time by default and supports
toggling between GPS, UTC, and UTC local time.

Resolve #3