### PR TITLE
Issue #17 - Update Messages datetime format call to use UTC time

### DIFF
--- a/bliss/gui/static/js/bliss/gui/Messages.js
+++ b/bliss/gui/static/js/bliss/gui/Messages.js
@@ -58,7 +58,7 @@ const Messages =
     view(vnode) {
         const rows = this._messages.map(msg =>
             m('div', {class: 'entry entry--' + msg.severity.toLowerCase()}, [
-                m('div', {class: 'timestamp'}, format.datetime(msg.timestamp)),
+                m('div', {class: 'timestamp'}, format.datetime(msg.timestamp, {utc: true, gps: false})),
                 m('div', {class: 'severity'}, msg.severity),
                 m('div', {class: 'message'}, msg.message)
             ])


### PR DESCRIPTION
The format.datetime call in Messages has been updated so that UTC
display format is explicitly stated. Note, this should be updated in the
future to mirror message display in the same format that the Clock
component is using for consistency.