### PR TITLE
Issue #61 - Adding tool tip to fieldname

### DIFF
--- a/ait/gui/static/css/ait/gui/Field.css
+++ b/ait/gui/static/css/ait/gui/Field.css
@@ -4,6 +4,10 @@ ait-field {
     cursor: pointer;
 }
 
+ait-field name {
+    font-weight: bold;
+}
+
 ait-field[disable-tlm-popover] {
     cursor: default;
 }

--- a/ait/gui/static/index.html
+++ b/ait/gui/static/index.html
@@ -103,10 +103,10 @@ information to foreign countries or providing access to foreign persons.
         <div class="col-sm-6">
           <h4 class="telem-group-title">1553 HS Voltages</h4>
           <table class="telem col2">
-            <tr> <td> Voltage_A: <ait-field packet="1553_HS_Packet" name="Voltage_A"></ait-field>
-                 <td> Voltage_B: <ait-field packet="1553_HS_Packet" name="Voltage_B"></ait-field>
-            <tr> <td> Voltage_C: <ait-field packet="1553_HS_Packet" name="Voltage_C"></ait-field>
-                 <td> Voltage_D: <ait-field packet="1553_HS_Packet" name="Voltage_D"></ait-field>
+            <tr> <td><ait-field packet="1553_HS_Packet" name="Voltage_A" display_name="Voltage_A"></ait-field>
+                 <td><ait-field packet="1553_HS_Packet" name="Voltage_B" display_name="Voltage_B"></ait-field>
+            <tr> <td><ait-field packet="1553_HS_Packet" name="Voltage_C" display_name="Voltage_C"></ait-field>
+                 <td><ait-field packet="1553_HS_Packet" name="Voltage_D" display_name="Voltage_D"></ait-field>
           </table>
 
           <br />
@@ -129,7 +129,7 @@ information to foreign countries or providing access to foreign persons.
         <div class="col-sm-6">
           <h4 class="telem-group-title">1553 HS Currents</h4>
           <table class="telem col2">
-            <tr> <td> Current_A: <ait-field packet="1553_HS_Packet" name="Current_A"></ait-field>
+            <tr> <td><ait-field packet="1553_HS_Packet" name="Current_A" display_name="Current_A"></ait-field>
           </table>
 
           <br />

--- a/ait/gui/static/js/ait/gui/Field.js
+++ b/ait/gui/static/js/ait/gui/Field.js
@@ -164,6 +164,7 @@ const Field =
     // Mithril lifecycle method
     oninit (vnode) {
         this._fname  = vnode.attrs.name
+        this._dname  = vnode.attrs.display_name
         this._pname  = vnode.attrs.packet
         this._raw    = vnode.attrs.raw === true
         this._cached = { packet: null, val: null }
@@ -363,7 +364,8 @@ const Field =
                 }
             }
 
-        return m('ait-field', vnode.attrs, value)
+        return m('ait-field', vnode.attrs, [m('name', this._dname + ': '), 
+                                            m('value', value)])
     }
 }
 

--- a/ait/gui/static/js/ait/gui/Field.js
+++ b/ait/gui/static/js/ait/gui/Field.js
@@ -164,7 +164,6 @@ const Field =
     // Mithril lifecycle method
     oninit (vnode) {
         this._fname  = vnode.attrs.name
-        this._dname  = vnode.attrs.display_name
         this._pname  = vnode.attrs.packet
         this._raw    = vnode.attrs.raw === true
         this._cached = { packet: null, val: null }
@@ -364,7 +363,12 @@ const Field =
                 }
             }
 
-        return m('ait-field', vnode.attrs, [m('name', this._dname + ': '), 
+        let dname = ""
+        if (vnode.attrs.display_name) {
+            dname = vnode.attrs.display_name + ': '
+        }
+
+        return m('ait-field', vnode.attrs, [m('name', dname), 
                                             m('value', value)])
     }
 }


### PR DESCRIPTION
Added `display_name` attribute to `ait-field` tag which `Field.view()` uses to return the following dom structure:

```
<ait-field> 
    <name>[display_name: ]</name>
    <value>[value]</field>
</ait-field>
```

Added css class for making `name` bold.

Resolves #61 