### PR TITLE
Issue #110 - Made GUI port optionally configurable

### DIFF
--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -171,11 +171,7 @@ class AITGUIPlugin(Plugin):
 
         bottle.TEMPLATE_PATH.append(HTMLRoot.User)
 
-        port = 8080
-        if 'port' in kwargs:
-            port = int(kwargs['port'])
-
-        gevent.spawn(self.init, port=port)
+        gevent.spawn(self.init)
 
     def process(self, input_data, topic=None):
         # msg is going to be a tuple from the ait_packet_handler
@@ -220,7 +216,7 @@ class AITGUIPlugin(Plugin):
     def getBrowserName(self, browser):
         return getattr(browser, 'name', getattr(browser, '_name', '(none)'))
 
-    def init(self, host=None, port=8080):
+    def init(self):
 
         # The /cmd endpoint requires access to the AITGUIPlugin object so it
         # can publish commands via the Plugin interface. It's defined here with
@@ -259,7 +255,14 @@ class AITGUIPlugin(Plugin):
         def handle(pathname):
             return bottle.static_file(pathname, root=HTMLRoot.User)
 
-        if host is None:
+        if hasattr(self, 'port'):
+            port = int(self.port)
+        else:
+            port = 8080
+
+        if hasattr(self, 'host'):
+            host = self.host
+        else:
             host = 'localhost'
 
         streams = ait.config.get('gui.telemetry')

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -256,7 +256,7 @@ class AITGUIPlugin(Plugin):
             return bottle.static_file(pathname, root=HTMLRoot.User)
 
         port = int(getattr(self, 'port', 8080)):
-        host = getattr(self, 'port', 'localhost'):
+        host = getattr(self, 'host', 'localhost'):
 
         streams = ait.config.get('gui.telemetry')
 

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -216,7 +216,7 @@ class AITGUIPlugin(Plugin):
     def getBrowserName(self, browser):
         return getattr(browser, 'name', getattr(browser, '_name', '(none)'))
 
-    def init(self, host=None, port=8080):
+    def init(self, host=None, port=ait.config.get('gui.port', 8080)):
 
         # The /cmd endpoint requires access to the AITGUIPlugin object so it
         # can publish commands via the Plugin interface. It's defined here with

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -255,15 +255,8 @@ class AITGUIPlugin(Plugin):
         def handle(pathname):
             return bottle.static_file(pathname, root=HTMLRoot.User)
 
-        if hasattr(self, 'port'):
-            port = int(self.port)
-        else:
-            port = 8080
-
-        if hasattr(self, 'host'):
-            host = self.host
-        else:
-            host = 'localhost'
+        port = int(getattr(self, 'port', 8080)):
+        host = getattr(self, 'port', 'localhost'):
 
         streams = ait.config.get('gui.telemetry')
 

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -171,7 +171,11 @@ class AITGUIPlugin(Plugin):
 
         bottle.TEMPLATE_PATH.append(HTMLRoot.User)
 
-        gevent.spawn(self.init)
+        port = 8080
+        if 'port' in kwargs:
+            port = int(kwargs['port'])
+
+        gevent.spawn(self.init, port=port)
 
     def process(self, input_data, topic=None):
         # msg is going to be a tuple from the ait_packet_handler
@@ -216,7 +220,7 @@ class AITGUIPlugin(Plugin):
     def getBrowserName(self, browser):
         return getattr(browser, 'name', getattr(browser, '_name', '(none)'))
 
-    def init(self, host=None, port=ait.config.get('gui.port', 8080)):
+    def init(self, host=None, port=8080):
 
         # The /cmd endpoint requires access to the AITGUIPlugin object so it
         # can publish commands via the Plugin interface. It's defined here with


### PR DESCRIPTION
Instead of defaulting to port 8080, the ait gui should now look at the
ait config and pull the defined gui.port number from there if its defined.
If it is not defined, then it will use the default of 8080. All of which
gets overwritten if the user provided a port number to the init method