### PR TITLE
Issue #129 - Add error handling for playback module datastore connection

### DIFF
--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -164,11 +164,15 @@ class Playback(object):
                 break
 
         if datastore:
-            mod, cls = datastore.rsplit('.', 1)
+            try:
+                mod, cls = datastore.rsplit('.', 1)
 
-            # Connect to database
-            self.dbconn = getattr(importlib.import_module(mod), cls)()
-            self.dbconn.connect(**other_args)
+                # Connect to database
+                self.dbconn = getattr(importlib.import_module(mod), cls)()
+                self.dbconn.connect(**other_args)
+            except Exception as e:
+                log.error('Error connecting to datastore {}: {}'.format(datastore, e))
+                log.warn('Disabling telemetry playback.')
         else:
             msg = (
                 '[GUI Playback Configuration]'

--- a/ait/gui/static/js/ait/gui/Playback.js
+++ b/ait/gui/static/js/ait/gui/Playback.js
@@ -54,10 +54,19 @@ const Playback = {
         // Display time ranges available
         let range = m('div', {class: 'form-group'}, [
             m('label', 'Time ranges available'),
-            this._range.map(function(i) {
-                return m('div', i[0] + ': ' + i[1] + ' to ' + i[2])
-            })
+            m('div', {'class': 'alert alert-warning'},
+                'No time ranges found. Is your database connection configured?'
+            )
         ])
+
+        if (this._range.length > 0) {
+            range = m('div', {class: 'form-group'}, [
+                m('label', 'Time ranges available'),
+                this._range.map(function(i) {
+                    return m('div', i[0] + ': ' + i[1] + ' to ' + i[2])
+                })
+            ])
+        }
 
         // Packet select drop down menu
         let packets = m('div', {class: 'form-group col-xs-3'}, [


### PR DESCRIPTION
Previously, failure to connect to the specified datastore crashed the GUI plugin. 
Now, on a failed datastore connection the playback functionality will not work but the rest of the GUI will continue to run.