### PR TITLE
Issue #105 - Rework of Backend/Frontend telemetry processing

### DIFF
--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -659,8 +659,6 @@ def handle():
                     if v.uid == uid:
                         pkt_defn = v
                         break
-                else:
-                    continue
 
                 wsock.send(json.dumps({
                     'packet': pkt_defn.name,
@@ -704,8 +702,6 @@ def handle():
                         if v.uid == uid:
                             pkt_defn = v
                             break
-                    else:
-                        continue
 
                     wsock.send(json.dumps({
                         'packet': pkt_defn.name,

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -691,11 +691,7 @@ def handle():
         while not wsock.closed:
             try:
                 uid, data = session.telemetry.popleft(timeout=30)
-                pkt_defn = None
-                for k, v in tlmdict.iteritems():
-                    if v.uid == uid:
-                        pkt_defn = v
-                        break
+                pkt_defn = getPacketDefn(uid)
 
                 wsock.send(json.dumps({
                     'packet': pkt_defn.name,

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -81,18 +81,26 @@ class Session (object):
         return self.tlm_counters[pkt_name]
 
 
+packet_defns = {}
 def getPacketDefn(uid):
     """
     Returns packet defn from tlm dict matching uid.
     Logs warning and returns None if no defn matching uid is found.
     """
-    tlmdict = ait.core.tlm.getDefaultDict()
-    for k, v in tlmdict.iteritems():
-        if v.uid == uid:
-            return v
+    global packet_defns
 
-    log.warn('No packet defn matching UID {}'.format(uid))
-    return None
+    if uid in packet_defns:
+        return packet_defns[uid]
+
+    else:
+        tlmdict = ait.core.tlm.getDefaultDict()
+        for k, v in tlmdict.iteritems():
+            if v.uid == uid:
+                packet_defns[uid] = v
+                return v
+
+        log.warn('No packet defn matching UID {}'.format(uid))
+        return None
 
 
 class SessionStore (dict):

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -726,7 +726,9 @@ def get_packet_delta(pkt_defn, packet):
 
     # previous packets of this type received
     else:
-        counters[pkt_defn.name] += 1
+        count = counters[pkt_defn.name]
+        count = count + 1 if count < 2**31 - 1 else 0
+        counters[pkt_defn.name] = count
         delta, dntoeus = {}, {}
         for field, new_value in json_pkt.items():
             last_value = packet_states[pkt_defn.name][field]
@@ -773,6 +775,7 @@ def handle():
                     delta, dntoeus, counter = get_packet_delta(pkt_defn, data)
                     delta = replace_datetimes(delta)
                     log.info(delta)
+                    log.info('Packet #{}'.format(counter))
 
                     wsock.send(json.dumps({
                         'packet': pkt_defn.name,

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -699,6 +699,7 @@ def add_dntoeu_value(field, packet, dntoeus):
 
 
 packet_states = { }
+counters = { }
 def get_packet_delta(pkt_defn, packet):
     """
     Keeps track of last packets recieved of all types recieved
@@ -715,6 +716,7 @@ def get_packet_delta(pkt_defn, packet):
 
     # first packet of this type
     if pkt_defn.name not in packet_states:
+        counters[pkt_defn.name] = 0
         packet_states[pkt_defn.name] = json_pkt
         delta = json_pkt
 
@@ -724,6 +726,7 @@ def get_packet_delta(pkt_defn, packet):
 
     # previous packets of this type received
     else:
+        counters[pkt_defn.name] += 1
         delta, dntoeus = {}, {}
         for field, new_value in json_pkt.items():
             last_value = packet_states[pkt_defn.name][field]
@@ -732,7 +735,7 @@ def get_packet_delta(pkt_defn, packet):
                 packet_states[pkt_defn.name][field] = new_value
                 dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
 
-    return delta, dntoeus
+    return delta, dntoeus, counters[pkt_defn.name]
 
 
 def replace_datetimes(delta):
@@ -767,14 +770,15 @@ def handle():
                             pkt_defn = v
                             break
 
-                    delta, dntoeus = get_packet_delta(pkt_defn, data)
+                    delta, dntoeus, counter = get_packet_delta(pkt_defn, data)
                     delta = replace_datetimes(delta)
                     log.info(delta)
 
                     wsock.send(json.dumps({
                         'packet': pkt_defn.name,
                         'data': delta,
-                        'dntoeus': dntoeus
+                        'dntoeus': dntoeus,
+                        'counter': counter
                     }))
 
                 except IndexError:
@@ -796,7 +800,11 @@ def handle():
 @App.route('/tlm/latest', method='GET')
 def handle():
     """Return latest telemetry packet to client"""
-    return json.dumps(packet_states)
+    for pkt_type, state in packet_states.items():
+        packet_states[pkt_type] = replace_datetimes(state)
+
+    return json.dumps({'states': packet_states,
+                       'counters': counters})
 
 
 @App.route('/tlm/query', method='POST')

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -117,9 +117,7 @@ class SessionStore (dict):
         delta = replace_datetimes(delta)
 
         for session in self.values():
-            print(session)
             counter = session.updateCounter(pkt_name)
-            print(session.tlm_counters)
             item = (pkt_name, delta, dntoeus, counter)
             session.deltas.append(item)
             item = (uid, packet, session.tlm_counters[pkt_name])
@@ -731,7 +729,11 @@ def add_dntoeu_value(field, packet, dntoeus):
     """
     field_defn = packet._defn.fieldmap[field]
     if field_defn.dntoeu:
-        dntoeus[field] = field_defn.dntoeu.eval(packet)
+        value = field_defn.dntoeu.eval(packet)
+        # to send to frontend
+        dntoeus[field] = value
+        # track on backend
+        packet_states[packet._defn.name]['dntoeu'][field] = value
 
     return dntoeus
 
@@ -753,10 +755,12 @@ def get_packet_delta(pkt_defn, packet):
 
     # first packet of this type
     if pkt_defn.name not in packet_states:
-        packet_states[pkt_defn.name] = json_pkt
+        packet_states[pkt_defn.name] = {}
+        packet_states[pkt_defn.name]['raw'] = json_pkt
         delta = json_pkt
 
         dntoeus = {}
+        packet_states[pkt_defn.name]['dntoeu'] = {}
         for field, value in json_pkt.items():
             dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
 
@@ -764,10 +768,10 @@ def get_packet_delta(pkt_defn, packet):
     else:
         delta, dntoeus = {}, {}
         for field, new_value in json_pkt.items():
-            last_value = packet_states[pkt_defn.name][field]
+            last_value = packet_states[pkt_defn.name]['raw'][field]
             if new_value != last_value:
                 delta[field] = new_value
-                packet_states[pkt_defn.name][field] = new_value
+                packet_states[pkt_defn.name]['raw'][field] = new_value
                 dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
 
     return delta, dntoeus
@@ -798,7 +802,6 @@ def handle():
             while not wsock.closed:
                 try:
                     name, delta, dntoeus, counter = session.deltas.popleft(timeout=30)
-                    log.info(delta)
                     log.info('packet #{}'.format(counter))
 
                     wsock.send(json.dumps({
@@ -828,8 +831,9 @@ def handle():
 def handle():
     """Return latest telemetry packet to client"""
     for pkt_type, state in packet_states.items():
-        packet_states[pkt_type] = replace_datetimes(state)
+        packet_states[pkt_type]['raw'] = replace_datetimes(state['raw'])
 
+    log.info(packet_states)
     with Sessions.current() as session:
         counters = session.tlm_counters
         return json.dumps({'states': packet_states,

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -681,31 +681,57 @@ def handle():
         pass
 
 
+def add_dntoeu_value(field, packet, dntoeus):
+    """
+    Returns dntoeu value of field from packet.
+
+    Params:
+        field: str name of field to evaluate
+        packet: AIT Packet
+        dntoeus: dict of dntoeu values to add to
+    """
+    field_defn = packet._defn.fieldmap[field]
+    if field_defn.dntoeu:
+        dntoeus[field] = field_defn.dntoeu.eval(packet)
+
+    return dntoeus
+
+
 last_packets = { }
 def get_packet_delta(pkt_defn, packet):
     """
     Keeps track of last packets recieved of all types recieved
-    and checks returns only fields that have changed since last
-    packet.
+    and returns only fields that have changed since last packet.
 
     Params:
         pkt_defn:  Packet definition
-        packet:    Packet in JSON format
+        packet:    Binary packet data
     Returns:
         delta:     JSON of packet fields that have changed
     """
+    ait_pkt = ait.core.tlm.Packet(pkt_defn, data=packet)
+    json_pkt = ait_pkt.toJSON()
+
+    # first packet of this type
     if pkt_defn.name not in last_packets:
-        last_packets[pkt_defn.name] = packet
-        delta = packet
+        last_packets[pkt_defn.name] = json_pkt
+        delta = json_pkt
+
+        dntoeus = {}
+        for field, value in json_pkt.items():
+            dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
+
+    # previous packets of this type received
     else:
-        delta = { }
-        for field, new_value in packet.items():
+        delta, dntoeus = {}, {}
+        for field, new_value in json_pkt.items():
             last_value = last_packets[pkt_defn.name][field]
             if new_value != last_value:
                 delta[field] = new_value
                 last_packets[pkt_defn.name][field] = new_value
+                dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
 
-    return delta
+    return delta, dntoeus
 
 
 @App.route('/tlm/realtime')
@@ -730,12 +756,12 @@ def handle():
                             pkt_defn = v
                             break
 
-                    json_pkt = ait.core.tlm.Packet(pkt_defn, data=data).toJSON()
-                    delta = get_packet_delta(pkt_defn, json_pkt)
+                    delta, dntoeus = get_packet_delta(pkt_defn, data)
 
                     wsock.send(json.dumps({
                         'packet': pkt_defn.name,
-                        'data': delta
+                        'data': delta,
+                        'dntoeus': dntoeus
                     }))
 
                 except IndexError:

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -639,6 +639,7 @@ def handle():
             __setResponseToEventStream()
             yield 'data: %s\n\n' % json.dumps(msg)
 
+
 @App.route('/tlm/realtime/openmct')
 def handle():
     """Return telemetry packets in realtime to client"""
@@ -697,7 +698,7 @@ def add_dntoeu_value(field, packet, dntoeus):
     return dntoeus
 
 
-last_packets = { }
+packet_states = { }
 def get_packet_delta(pkt_defn, packet):
     """
     Keeps track of last packets recieved of all types recieved
@@ -713,8 +714,8 @@ def get_packet_delta(pkt_defn, packet):
     json_pkt = ait_pkt.toJSON()
 
     # first packet of this type
-    if pkt_defn.name not in last_packets:
-        last_packets[pkt_defn.name] = json_pkt
+    if pkt_defn.name not in packet_states:
+        packet_states[pkt_defn.name] = json_pkt
         delta = json_pkt
 
         dntoeus = {}
@@ -725,10 +726,10 @@ def get_packet_delta(pkt_defn, packet):
     else:
         delta, dntoeus = {}, {}
         for field, new_value in json_pkt.items():
-            last_value = last_packets[pkt_defn.name][field]
+            last_value = packet_states[pkt_defn.name][field]
             if new_value != last_value:
                 delta[field] = new_value
-                last_packets[pkt_defn.name][field] = new_value
+                packet_states[pkt_defn.name][field] = new_value
                 dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
 
     return delta, dntoeus
@@ -783,25 +784,7 @@ def handle():
 @App.route('/tlm/latest', method='GET')
 def handle():
     """Return latest telemetry packet to client"""
-    with Sessions.current() as session:
-        tlmdict = ait.core.tlm.getDefaultDict()
-        uid, data = session.telemetry.popleft(timeout=30)
-        pkt_defn = None
-        for k, v in tlmdict.iteritems():
-            if v.uid == uid:
-                pkt_defn = v
-                break
-
-        ait_pkt = ait.core.tlm.Packet(pkt_defn, data=data)
-        json_pkt = ait_pkt.toJSON()
-        for field, value in json_pkt.items():
-            dntoeus = add_dntoeu_value(field, ait_pkt, {})
-
-        return json.dumps({
-            'packet': pkt_defn.name,
-            'data': json_pkt,
-            'dntoeus': dntoeus
-        })
+    return json.dumps(packet_states)
 
 
 @App.route('/tlm/query', method='POST')

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -780,6 +780,30 @@ def handle():
             pass
 
 
+@App.route('/tlm/latest', method='GET')
+def handle():
+    """Return latest telemetry packet to client"""
+    with Sessions.current() as session:
+        tlmdict = ait.core.tlm.getDefaultDict()
+        uid, data = session.telemetry.popleft(timeout=30)
+        pkt_defn = None
+        for k, v in tlmdict.iteritems():
+            if v.uid == uid:
+                pkt_defn = v
+                break
+
+        ait_pkt = ait.core.tlm.Packet(pkt_defn, data=data)
+        json_pkt = ait_pkt.toJSON()
+        for field, value in json_pkt.items():
+            dntoeus = add_dntoeu_value(field, ait_pkt, {})
+
+        return json.dumps({
+            'packet': pkt_defn.name,
+            'data': json_pkt,
+            'dntoeus': dntoeus
+        })
+
+
 @App.route('/tlm/query', method='POST')
 def handle():
     """"""

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -735,6 +735,16 @@ def get_packet_delta(pkt_defn, packet):
     return delta, dntoeus
 
 
+def replace_datetimes(delta):
+    """Replace datetime objects with ISO formatted
+    strings for JSON serialization"""
+    for key, val in delta.items():
+        if type(val) is datetime:
+            delta[key] = val.isoformat()
+
+    return delta
+
+
 @App.route('/tlm/realtime')
 def handle():
     """Return telemetry packets in realtime to client"""
@@ -758,6 +768,8 @@ def handle():
                             break
 
                     delta, dntoeus = get_packet_delta(pkt_defn, data)
+                    delta = replace_datetimes(delta)
+                    log.info(delta)
 
                     wsock.send(json.dumps({
                         'packet': pkt_defn.name,

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -69,6 +69,30 @@ class Session (object):
         """A unique identifier for this Session."""
         return str( id(self) )
 
+    def updateCounter(self, pkt_name)
+        if pkt_name not in self.tlm_counters:
+            self.tlm_counters[pkt_name] = 0
+        else:
+            count = self.tlm_counters[pkt_name]
+            count = count + 1 if count < 2**31 - 1 else 0
+            self.tlm_counters[pkt_name] = count
+
+        return self.tlm_counters[pkt_name]
+
+
+def getPacketDefn(uid):
+    """
+    Returns packet defn from tlm dict matching uid.
+    Logs warning and returns None if no defn matching uid is found.
+    """
+    tlmdict = ait.core.tlm.getDefaultDict()
+    for k, v in tlmdict.iteritems():
+        if v.uid == uid:
+            return v
+
+    log.warn('No packet defn matching UID {}'.format(uid))
+    return None
+
 
 class SessionStore (dict):
     """SessionStore
@@ -81,18 +105,6 @@ class SessionStore (dict):
         """Creates a new SessionStore."""
         dict.__init__(self, *args, **kwargs)
 
-    def getPacketName(self, uid):
-        """
-        Returns packet defn from tlm dict matching uid.
-        Logs error if no defn matching uid is found.
-        """
-        tlmdict = ait.core.tlm.getDefaultDict()
-        for k, v in tlmdict.iteritems():
-            if v.uid == uid:
-                return v
-
-        log.error('No packet defn matching UID {}'.format(uid))
-
     def addTelemetry (self, uid, packet):
         """Adds a telemetry packet to all Sessions in the store."""
         item = (uid, packet)
@@ -101,13 +113,8 @@ class SessionStore (dict):
         for session in self.values():
             print(session)
 
-            pkt_name = self.getPacketName(uid).name
-            if pkt_name not in session.tlm_counters:
-                session.tlm_counters[pkt_name] = 0
-            else:
-                count = session.tlm_counters[pkt_name]
-                count = count + 1 if count < 2**31 - 1 else 0
-                session.tlm_counters[pkt_name] = count
+            pkt_name = getPacketDefn(uid).name
+            session.updateCounter(pkt_name)
 
             print(session.tlm_counters)
             item = (uid, packet, session.tlm_counters[pkt_name])
@@ -783,16 +790,10 @@ def handle():
             bottle.abort(400, 'Expected WebSocket request.')
 
         try:
-            tlmdict = ait.core.tlm.getDefaultDict()
             while not wsock.closed:
                 try:
                     uid, data, counter = session.telemetry.popleft(timeout=30)
-                    pkt_defn = None
-                    for k, v in tlmdict.iteritems():
-                        if v.uid == uid:
-                            pkt_defn = v
-                            break
-
+                    pkt_defn = getPacketDefn(uid)
                     delta, dntoeus = get_packet_delta(pkt_defn, data)
                     delta = replace_datetimes(delta)
                     log.info(delta)

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -695,10 +695,23 @@ def handle():
             bottle.abort(400, 'Expected WebSocket request.')
 
         try:
+            tlmdict = ait.core.tlm.getDefaultDict()
             while not wsock.closed:
                 try:
                     uid, data = session.telemetry.popleft(timeout=30)
-                    wsock.send(pad + struct.pack('>I', uid) + data)
+                    pkt_defn = None
+                    for k, v in tlmdict.iteritems():
+                        if v.uid == uid:
+                            pkt_defn = v
+                            break
+                    else:
+                        continue
+
+                    wsock.send(json.dumps({
+                        'packet': pkt_defn.name,
+                        'data': ait.core.tlm.Packet(pkt_defn, data=data).toJSON()
+                    }))
+
                 except IndexError:
                     # If no telemetry has been received by the GUI
                     # server after timeout seconds, "probe" the client

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -798,7 +798,6 @@ def handle():
             while not wsock.closed:
                 try:
                     name, delta, dntoeus, counter = session.deltas.popleft(timeout=30)
-                    log.info('packet #{}'.format(counter))
 
                     wsock.send(json.dumps({
                         'packet': name,
@@ -829,7 +828,6 @@ def handle():
     for pkt_type, state in packet_states.items():
         packet_states[pkt_type]['raw'] = replace_datetimes(state['raw'])
 
-    log.info(packet_states)
     with Sessions.current() as session:
         counters = session.tlm_counters
         return json.dumps({'states': packet_states,

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -722,26 +722,6 @@ def handle():
         pass
 
 
-def add_dntoeu_value(field, packet, dntoeus):
-    """
-    Returns dntoeu value of field from packet.
-
-    Params:
-        field: str name of field to evaluate
-        packet: AIT Packet
-        dntoeus: dict of dntoeu values to add to
-    """
-    field_defn = packet._defn.fieldmap[field]
-    if field_defn.dntoeu:
-        value = field_defn.dntoeu.eval(packet)
-        # to send to frontend
-        dntoeus[field] = value
-        # track on backend
-        packet_states[packet._defn.name]['dntoeu'][field] = value
-
-    return dntoeus
-
-
 packet_states = { }
 def get_packet_delta(pkt_defn, packet):
     """
@@ -755,28 +735,36 @@ def get_packet_delta(pkt_defn, packet):
         delta:     JSON of packet fields that have changed
     """
     ait_pkt = ait.core.tlm.Packet(pkt_defn, data=packet)
-    json_pkt = ait_pkt.toJSON()
 
     # first packet of this type
     if pkt_defn.name not in packet_states:
         packet_states[pkt_defn.name] = {}
-        packet_states[pkt_defn.name]['raw'] = json_pkt
-        delta = json_pkt
 
-        dntoeus = {}
+        # get raw fields
+        raw_fields = {f.name: getattr(ait_pkt.raw, f.name) for f in pkt_defn.fields}
+        packet_states[pkt_defn.name]['raw'] = raw_fields
+        delta = raw_fields
+
+        # get converted fields
         packet_states[pkt_defn.name]['dntoeu'] = {}
-        for field, value in json_pkt.items():
-            dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
+        dntoeus = {f.name: getattr(ait_pkt, f.name) for f in pkt_defn.fields if f.dntoeu is not None}
 
     # previous packets of this type received
     else:
         delta, dntoeus = {}, {}
-        for field, new_value in json_pkt.items():
-            last_value = packet_states[pkt_defn.name]['raw'][field]
+
+        for field in pkt_defn.fields:
+            new_value = getattr(ait_pkt.raw, field.name)
+            last_value = packet_states[pkt_defn.name]['raw'][field.name]
+
             if new_value != last_value:
-                delta[field] = new_value
-                packet_states[pkt_defn.name]['raw'][field] = new_value
-                dntoeus = add_dntoeu_value(field, ait_pkt, dntoeus)
+                delta[field.name] = new_value
+                packet_states[pkt_defn.name]['raw'][field.name] = new_value
+
+                if field.dntoeu is not None:
+                    dntoeu_val = getattr(ait_pkt, field.name)
+                    dntoeus[field.name] = dntoeu_val
+                    packet_states[pkt_defn.name]['dntoeu'][field.name] = dntoeu_val
 
     return delta, dntoeus
 

--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -681,6 +681,33 @@ def handle():
         pass
 
 
+last_packets = { }
+def get_packet_delta(pkt_defn, packet):
+    """
+    Keeps track of last packets recieved of all types recieved
+    and checks returns only fields that have changed since last
+    packet.
+
+    Params:
+        pkt_defn:  Packet definition
+        packet:    Packet in JSON format
+    Returns:
+        delta:     JSON of packet fields that have changed
+    """
+    if pkt_defn.name not in last_packets:
+        last_packets[pkt_defn.name] = packet
+        delta = packet
+    else:
+        delta = { }
+        for field, new_value in packet.items():
+            last_value = last_packets[pkt_defn.name][field]
+            if new_value != last_value:
+                delta[field] = new_value
+                last_packets[pkt_defn.name][field] = new_value
+
+    return delta
+
+
 @App.route('/tlm/realtime')
 def handle():
     """Return telemetry packets in realtime to client"""
@@ -703,9 +730,12 @@ def handle():
                             pkt_defn = v
                             break
 
+                    json_pkt = ait.core.tlm.Packet(pkt_defn, data=data).toJSON()
+                    delta = get_packet_delta(pkt_defn, json_pkt)
+
                     wsock.send(json.dumps({
                         'packet': pkt_defn.name,
-                        'data': ait.core.tlm.Packet(pkt_defn, data=data).toJSON()
+                        'data': delta
                     }))
 
                 except IndexError:

--- a/ait/gui/static/js/ait/gui/Field.js
+++ b/ait/gui/static/js/ait/gui/Field.js
@@ -83,7 +83,7 @@ const Field =
      * retrieving the packet value.
      */
     getValue (packet, raw=false) {
-        return packet && packet.__get__(this._fname, raw)
+        return packet && packet[this._fname]
     },
 
 

--- a/ait/gui/static/js/ait/gui/Field.js
+++ b/ait/gui/static/js/ait/gui/Field.js
@@ -285,7 +285,8 @@ const Field =
     },
 
     onbeforeupdate (vnode, old) {
-        return this.hasChanged()
+        let changed = this.hasChanged()
+        return changed
     },
 
     view (vnode) {

--- a/ait/gui/static/js/ait/gui/Field.js
+++ b/ait/gui/static/js/ait/gui/Field.js
@@ -83,7 +83,13 @@ const Field =
      * retrieving the packet value.
      */
     getValue (packet, raw=false) {
-        return packet && packet[this._fname]
+        if ( !raw ) {
+            if ( packet && this._fname in packet['dntoeu']) {
+                return packet && packet['dntoeu'][this._fname]
+            }
+        }
+
+        return packet && packet['raw'][this._fname]
     },
 
 

--- a/ait/gui/static/js/ait/gui/Field.js
+++ b/ait/gui/static/js/ait/gui/Field.js
@@ -291,8 +291,7 @@ const Field =
     },
 
     onbeforeupdate (vnode, old) {
-        let changed = this.hasChanged()
-        return changed
+        return this.hasChanged() 
     },
 
     view (vnode) {

--- a/ait/gui/static/js/ait/gui/Plot.js
+++ b/ait/gui/static/js/ait/gui/Plot.js
@@ -78,13 +78,14 @@ class DygraphsBackend
         }
     }
 
-    plot (packet) {
-        const pname = packet._defn.name
+    plot (data) {
+        const pname = data['packet']
+        let delta = data['data']
         const names = this._plot._packets[pname]
 
         if (!names) return
 
-        let row = [ this._plot._time.get(packet) ]
+        let row = [ this._plot._time.get(delta) ]
 
         // For each series of data, if it's in the current packet
         // that we're updating, add the associated point. Otherwise,
@@ -92,7 +93,7 @@ class DygraphsBackend
         // to the plot maintains the same "shape" as the labels.
         this._series.forEach((id) => {
             if (id.startsWith(pname)) {
-                row.push(packet.__get__(id.split('.')[1]))
+                row.push(delta[id.split('.')[1]])
             } else {
                 row.push(null)
             }
@@ -207,8 +208,8 @@ class HighchartsBackend
         Object.assign(options, overrides)
     }
 
-    plot(packet) {
-        const pname = packet._defn.name
+    plot(delta) {
+        const pname = delta['packet']
         const names = this._plot._packets[pname]
         if (!names) return
 
@@ -354,10 +355,10 @@ class HighchartsBackend
 const Plot =
 {
     /**
-     * Plots data from the given packet.
+     * Plots data from the given delta.
      */
-    plot (packet) {
-        this._backend.plot(packet)
+    plot (delta) {
+        this._backend.plot(delta)
     },
 
 

--- a/ait/gui/static/js/ait/gui/Plot.js
+++ b/ait/gui/static/js/ait/gui/Plot.js
@@ -80,7 +80,7 @@ class DygraphsBackend
 
     plot (data) {
         const pname = data['packet']
-        let packet = data['data']
+        let packet = data['data']['raw']
         const names = this._plot._packets[pname]
 
         if (!names) return
@@ -209,7 +209,7 @@ class HighchartsBackend
 
     plot(data) {
         const pname = data['packet']
-        let packet = data['data']
+        let packet = data['data']['raw']
         const names = this._plot._packets[pname]
         if (!names) return
 

--- a/ait/gui/static/js/ait/gui/Plot.js
+++ b/ait/gui/static/js/ait/gui/Plot.js
@@ -86,8 +86,6 @@ class DygraphsBackend
         if (!names) return
 
         let row = [ this._plot._time.get(packet) ]
-        console.log("Received by plotting:")
-        console.log(packet)
         // For each series of data, if it's in the current packet
         // that we're updating, add the associated point. Otherwise,
         // add a null value. Dygraphs requires that the data added

--- a/ait/gui/static/js/ait/gui/Plot.js
+++ b/ait/gui/static/js/ait/gui/Plot.js
@@ -86,6 +86,7 @@ class DygraphsBackend
         if (!names) return
 
         let row = [ this._plot._time.get(packet) ]
+        console.log("Received by plotting:")
         console.log(packet)
         // For each series of data, if it's in the current packet
         // that we're updating, add the associated point. Otherwise,

--- a/ait/gui/static/js/ait/gui/Plot.js
+++ b/ait/gui/static/js/ait/gui/Plot.js
@@ -208,8 +208,9 @@ class HighchartsBackend
         Object.assign(options, overrides)
     }
 
-    plot(delta) {
-        const pname = delta['packet']
+    plot(data) {
+        const pname = data['packet']
+        let delta = data['data']
         const names = this._plot._packets[pname]
         if (!names) return
 
@@ -217,8 +218,8 @@ class HighchartsBackend
             const series = this._plot._chart.get(pname + '.' + name)
 
             if (series) {
-                const x = this._plot._time.get(packet).getTime()
-                const y = packet.__get__(name)
+                const x = this._plot._time.get(delta).getTime()
+                const y = delta[name]
 
                 series.addPoint([x, y], false)
 

--- a/ait/gui/static/js/ait/gui/Plot.js
+++ b/ait/gui/static/js/ait/gui/Plot.js
@@ -80,12 +80,12 @@ class DygraphsBackend
 
     plot (data) {
         const pname = data['packet']
-        let delta = data['data']
+        let packet = data['data']
         const names = this._plot._packets[pname]
 
         if (!names) return
 
-        let row = [ this._plot._time.get(delta) ]
+        let row = [ this._plot._time.get(packet) ]
 
         // For each series of data, if it's in the current packet
         // that we're updating, add the associated point. Otherwise,
@@ -93,7 +93,7 @@ class DygraphsBackend
         // to the plot maintains the same "shape" as the labels.
         this._series.forEach((id) => {
             if (id.startsWith(pname)) {
-                row.push(delta[id.split('.')[1]])
+                row.push(packet[id.split('.')[1]])
             } else {
                 row.push(null)
             }
@@ -210,7 +210,7 @@ class HighchartsBackend
 
     plot(data) {
         const pname = data['packet']
-        let delta = data['data']
+        let packet = data['data']
         const names = this._plot._packets[pname]
         if (!names) return
 
@@ -218,8 +218,8 @@ class HighchartsBackend
             const series = this._plot._chart.get(pname + '.' + name)
 
             if (series) {
-                const x = this._plot._time.get(delta).getTime()
-                const y = delta[name]
+                const x = this._plot._time.get(packet).getTime()
+                const y = packet[name]
 
                 series.addPoint([x, y], false)
 
@@ -356,10 +356,10 @@ class HighchartsBackend
 const Plot =
 {
     /**
-     * Plots data from the given delta.
+     * Plots data from the given packet.
      */
-    plot (delta) {
-        this._backend.plot(delta)
+    plot (packet) {
+        this._backend.plot(packet)
     },
 
 

--- a/ait/gui/static/js/ait/gui/Plot.js
+++ b/ait/gui/static/js/ait/gui/Plot.js
@@ -86,7 +86,7 @@ class DygraphsBackend
         if (!names) return
 
         let row = [ this._plot._time.get(packet) ]
-
+        console.log(packet)
         // For each series of data, if it's in the current packet
         // that we're updating, add the associated point. Otherwise,
         // add a null value. Dygraphs requires that the data added

--- a/ait/gui/static/js/ait/gui/Search.js
+++ b/ait/gui/static/js/ait/gui/Search.js
@@ -139,8 +139,12 @@ const MnemonicSearch = {
         )
 
         if (curPacket !== null) {
-            val = curPacket.__get__(this._selection)
-            raw = curPacket.__get__(this._selection, true)
+            if ( this._selection in curPacket['dntoeu']) {
+                val = curPacket['dntoeu'][this._selection]
+            } else {
+                val = curPacket['raw'][this._selection]
+            }
+            raw = curPacket['raw'][this._selection]
         }
 
         let data = {}

--- a/ait/gui/static/js/ait/gui/index.js
+++ b/ait/gui/static/js/ait/gui/index.js
@@ -197,6 +197,12 @@ function init () {
             ait.events.emit(e.name, e.data)
         });
 
+        m.request({ url: '/tlm/latest' }).then((latest) => {
+            ait.tlm.state = latest
+            console.log('requested latest tlm')
+            console.log(ait.tlm.state)
+        })
+
         m.mount(root, { view: () => createMithrilNodes(elems) })
     })
 }

--- a/ait/gui/static/js/ait/gui/index.js
+++ b/ait/gui/static/js/ait/gui/index.js
@@ -199,8 +199,6 @@ function init () {
 
         m.request({ url: '/tlm/latest' }).then((latest) => {
             ait.tlm.state = latest
-            console.log('requested latest tlm')
-            console.log(ait.tlm.state)
         })
 
         m.mount(root, { view: () => createMithrilNodes(elems) })

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -381,11 +381,12 @@ class TelemetryStream
 
 
     onMessage (event) {
-        if ( !(event.data instanceof ArrayBuffer) ) return
+        if ( !(typeof event.data == "string") ) return
 
-        let uid  = new DataView(event.data, 1, 4).getUint32(0)
-        let data = new DataView(event.data, 5)
-        let defn = this._dict[uid]
+        let now = Date.now()
+        let data = JSON.parse(event.data)
+        let packet_name = data['packet']
+        let delta = data['data']
 
         // Since WebSockets can stay open indefinitely, the AIT GUI
         // server will occasionally probe for dropped client
@@ -399,16 +400,15 @@ class TelemetryStream
         // It's also possible that the packet UID is not in the client
         // telemetry dictionary (defn === undefined).  Without a
         // packet definition, the packet cannot be processed further.
-        if ((uid == 0 && data.byteLength == 0) || !defn) return
-
-        let packet = Packet.create(defn, data)
 
         clearInterval(this._interval)
         this._stale    = 0
         this._interval = setInterval(this.onStale.bind(this), 5000)
 
-        ait.packets.insert(defn.name, packet)
-        this._emit('packet', packet)
+        console.log(packet_name)
+        console.log(delta)
+        ait.packets.insert(packet_name, delta)
+        this._emit('packet', data)
     }
 
 

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -356,7 +356,12 @@ class TelemetryStream
         this._socket   = new WebSocket(url)
         this._stale    = 0
         this._url      = url
-        this._pkt_states = { }
+        m.request({ url: '/tlm/latest' }).then((latest) => {
+            this._pkt_states = latest
+            console.log('requested latest tlm from within stream')
+            console.log(ait.tlm.state)
+        })
+        console.log(this._pkt_states)
 
         // Re-map telemetry dictionary to be keyed by a PacketDefinition
         // 'id' instead of 'name'.
@@ -390,6 +395,7 @@ class TelemetryStream
         let delta = data['data']
         let dntoeus = data['dntoeus']
 
+        console.log('packet states:')
         console.log(this._pkt_states)
 
         // add delta to last full packet
@@ -405,13 +411,13 @@ class TelemetryStream
             // delta is empty - request full packet from backend
             if ( Object.keys(delta).length == 0 ) {
                 m.request({ url: '/tlm/latest' }).then( (latest) => {
-                    packet_name = latest['packet']
-                    delta = latest['data']
-                    dntoeus = latest['dntoeus']
-                    console.log('here')
-                    console.log(delta)
+                    console.log('requesting latest tlm')
+                    console.log(latest)
+                    //ait.tlm.state = latest
+                    //packet_name = latest['packet']
+                    //delta = latest['data']
+                    //dntoeus = latest['dntoeus']
                 })
-                console.log(delta)
             } 
 
             this._pkt_states[packet_name] = delta

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -423,7 +423,7 @@ class TelemetryStream
                 if ( Object.keys(delta).length !== 0 ) {
                     console.log('adding delta to pkt state')
                     for ( var field in delta ) {
-                        this._pkt_states[packet_name][field] = this._pkt_states[packet_name][field] + delta[field]
+                        this._pkt_states[packet_name][field] = delta[field]
                     }
                 }
                 this._counters[packet_name] = counter

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -423,7 +423,10 @@ class TelemetryStream
                 if ( Object.keys(delta).length !== 0 ) {
                     console.log('adding delta to pkt state')
                     for ( var field in delta ) {
-                        this._pkt_states[packet_name][field] = delta[field]
+                        this._pkt_states[packet_name]['raw'][field] = delta[field]
+                    }
+                    for ( var field in dntoeus ) {
+                        this._pkt_states[packet_name]['dntoeu'][field] = dntoeus[field]
                     }
                 }
                 this._counters[packet_name] = counter
@@ -434,7 +437,9 @@ class TelemetryStream
                 // empty delta - request full packet from backend
                 this.getFullPacketStates()
             } else {
-                this._pkt_states[packet_name] = delta
+                this._pkt_states[packet_name] = {}
+                this._pkt_states[packet_name]['raw'] = delta
+                this._pkt_states[packet_name]['dntoeu'] = dntoeus
                 this._counters[packet_name] = counter
             }
         }

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -356,6 +356,7 @@ class TelemetryStream
         this._socket   = new WebSocket(url)
         this._stale    = 0
         this._url      = url
+        this._pkt_states = { }
 
         // Re-map telemetry dictionary to be keyed by a PacketDefinition
         // 'id' instead of 'name'.
@@ -388,6 +389,18 @@ class TelemetryStream
         let packet_name = data['packet']
         let delta = data['data']
 
+        // add delta to last full packet
+        // want full packet inserted in packet buffer & emitted as event
+        if ( Object.keys(delta).length !== 0 ) {
+            if ( packet_name in this._pkt_states ) {
+                for ( var field in delta ) {
+                    this._pkt_states[packet_name][field] = this._pkt_states[packet_name][field] + delta[field]
+                }
+            } else {
+                this._pkt_states[packet_name] = delta
+            }
+        }
+
         // Since WebSockets can stay open indefinitely, the AIT GUI
         // server will occasionally probe for dropped client
         // connections by sending empty packets (data.byteLength == 0)
@@ -405,10 +418,9 @@ class TelemetryStream
         this._stale    = 0
         this._interval = setInterval(this.onStale.bind(this), 5000)
 
-        console.log(packet_name)
-        console.log(delta)
-        ait.packets.insert(packet_name, delta)
-        this._emit('packet', data)
+        ait.packets.insert(packet_name, this._pkt_states[packet_name])
+        this._emit('packet', {'packet': packet_name,
+                              'data': this._pkt_states[packet_name]})
     }
 
 

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -394,9 +394,11 @@ class TelemetryStream
     checkCounter (packetName, counter) {
         // returns true if counter is as expected, false if not
         let lastCounter = this._counters[packetName]
-        if ( counter == lastCounter + 1 ) {
+        if ( counter == lastCounter + 1) {
             return true
-        } 
+        } else if ( lastCounter == Math.pow(2, 31) - 1 && counter == 0 ) {
+            return true
+        }
         console.log('counter mismatch: had ' + lastCounter + ' , got ' + counter)
         return false
     }

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -457,7 +457,8 @@ class TelemetryStream
         this._stale    = 0
         this._interval = setInterval(this.onStale.bind(this), 5000)
 
-        ait.packets.insert(packet_name, this._pkt_states[packet_name])
+        let current_pkt = JSON.parse(JSON.stringify(this._pkt_states[packet_name]))
+        ait.packets.insert(packet_name, current_pkt)
         this._emit('packet', {'packet': packet_name,
                               'data': this._pkt_states[packet_name]})
     }


### PR DESCRIPTION
- Add tracking of telemetry state on backend
- Only send changed packet fields to frontend (called "deltas")
- Use counter method to check if frontend has missed any packet deltas
    - counters kept per frontend session
    - frontend requests full packet state on startup and if delta missed
- Remove Packet processing from frontend

Resolves #105 