### PR TITLE
Issue #185 - Fix broken field formatting

### DIFF
--- a/ait/gui/static/js/ait/gui/Field.js
+++ b/ait/gui/static/js/ait/gui/Field.js
@@ -323,7 +323,7 @@ const Field =
         }
         else {
             if (vnode.attrs.format) {
-                const defn = packet._defn.fields[this._fname]
+                const defn = ait.tlm.dict[this._pname]._fields[this._fname]
                 const type = defn && defn.type
 
                 value = (type && type.isTime) ?

--- a/ait/gui/static/js/ait/gui/index.js
+++ b/ait/gui/static/js/ait/gui/index.js
@@ -134,7 +134,6 @@ function makeMithrilNode(e) {
 
 function filterNodes(n) {
     let nodes =  map(n, makeMithrilNode)
-    console.log(nodes)
     return nodes
 }
 

--- a/ait/gui/static/js/ait/tlm.js
+++ b/ait/gui/static/js/ait/tlm.js
@@ -279,8 +279,6 @@ class TelemetryStream
         this._stale    = 0
         this._url      = url
         this.getFullPacketStates()
-        console.log(this._pkt_states)
-        console.log(this._counters)
 
         // Re-map telemetry dictionary to be keyed by a PacketDefinition
         // 'id' instead of 'name'.
@@ -306,8 +304,6 @@ class TelemetryStream
 
     getFullPacketStates () {
         m.request({ url: '/tlm/latest' }).then( (latest) => {
-            console.log('requesting latest tlm')
-            console.log(latest)
             this._pkt_states = latest['states']
             this._counters = latest['counters']
         })
@@ -343,7 +339,6 @@ class TelemetryStream
             } else {
                 // add delta to current packet state and update counter
                 if ( Object.keys(delta).length !== 0 ) {
-                    console.log('adding delta to pkt state')
                     for ( var field in delta ) {
                         this._pkt_states[packet_name]['raw'][field] = delta[field]
                     }
@@ -354,7 +349,6 @@ class TelemetryStream
                 this._counters[packet_name] = counter
             }
         } else { // new packet type
-            console.log('new packet type')
             if ( Object.keys(delta).length == 0 ) {
                 // empty delta - request full packet from backend
                 this.getFullPacketStates()
@@ -366,7 +360,6 @@ class TelemetryStream
             }
         }
 
-        console.log("counter: ", this._counters[packet_name])
         // Since WebSockets can stay open indefinitely, the AIT GUI
         // server will occasionally probe for dropped client
         // connections by sending empty packets (data.byteLength == 0)


### PR DESCRIPTION
Field formatting now pulls a given fields packet definition from the
global ait.tlm.dict object instead of the "packet" being processed. The
packet passed around on message receipt was changed when the
front/backend exchange format was updated. The format handling
subsection was attempting to access the packet definition information
using the old format.

Drop a number of unneeded console.logs throughout.

Resolve #185 
Resolve #179 