### PR TITLE
Issue #194 - Fix improperly initialized 'dntoeu' packet states

### DIFF
--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -764,6 +764,7 @@ def get_packet_delta(pkt_defn, packet):
                     val = val.name
 
                 dntoeus[f.name] = val
+                packet_states[pkt_defn.name]['dntoeu'][f.name] = val
 
 
         # get derivations


### PR DESCRIPTION
Packet diff handling when previously unseen packet was received failed
to properly initialized the `dntoeu` values for that packet. This meant
that UI clients would be unable to view the "human readable" versions of
fields in the GUI for any field that updated infrequently. This updates
the new packet type handling to properly update the `dntoeu` values as
well.

Resolve #194