### PR TITLE
Issue #200 - Properly decode received log messages in GUI plugin

### DIFF
--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -327,6 +327,7 @@ class AITGUIPlugin(Plugin):
             Sessions.addTelemetry(msg[0], msg[1])
 
     def process_log_msg(self, msg):
+        msg = msg.decode()
         parsed = log.parseSyslog(msg)
         Sessions.addMessage(parsed)
 


### PR DESCRIPTION
Update the process_log_msg() helper to properly decode the received 0MQ
message from bytes into a str prior to passing it off to
log.parseSyslog. This necessary change was overlooked in our testing for
the new 0MQ send / recv call updates in Core / GUI.

Resolve #200