### PR TITLE
Issue #216 - Add Python3.7 dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
     namespace_packages   = ['ait'],
     include_package_data = True,
 
+    python_requires = '==3.7.*',
     install_requires = ['ait-core>=2.3.0'],
     extras_require = {
         'docs':  [


### PR DESCRIPTION
Because I spent a good amount of time before I discovered the strict dependency on Python3.7, I thought it would be a good idea to add this dependency to the setup script to make it explicit.

Resolves #216 
