### PR TITLE
Fix typo that makes call to log method that doesn't exist

### DIFF
--- a/ait/gui/__init__.py
+++ b/ait/gui/__init__.py
@@ -328,7 +328,7 @@ class AITGUIPlugin(Plugin):
 
     def process_log_msg(self, msg):
         msg = msg.decode()
-        parsed = log.parseSyslog(msg)
+        parsed = log.parse_syslog(msg)
         Sessions.addMessage(parsed)
 
     def getBrowserName(self, browser):


### PR DESCRIPTION
The original function name does not exist in the AIT core log module and looks to be a typo.
This causes an immediate error when using AIT-GUI.  

Changed the line to use the call in AIT core.
The error no longer appears. 