### PR TITLE
Issue #243 - Add RTD build status badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://readthedocs.org/projects/ait-gui/badge/?version=latest
+    :target: https://ait-gui.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 AMMOS Instrument Toolkit (AIT) GUI
 ==================================
 


### PR DESCRIPTION
Add RTD docs build badge to the top of the README.

Resolve #243
